### PR TITLE
[feat] 북마크 토글 API 연동

### DIFF
--- a/Spon-Us/Bookmark/BookmarkView.swift
+++ b/Spon-Us/Bookmark/BookmarkView.swift
@@ -23,11 +23,7 @@ struct BookmarkView: View {
             HStack {
                 Button(action: {
                     selectedBookmark = .recent
-                    bookmarkViewModel.fetchBookmarks(sort: .recent) { success in
-                        if !success {
-                            print("Failed to fetch recent bookmarks")
-                        }
-                    }
+                    fetchBookmarksForSelectedBookmark()
                 }, label: {
                     Text("최근 본")
                         .korFont(.T4KrBd)
@@ -39,11 +35,7 @@ struct BookmarkView: View {
                 
                 Button(action: {
                     selectedBookmark = .company
-                    bookmarkViewModel.fetchBookmarks(sort: .company) { success in
-                        if !success {
-                            print("Failed to fetch company bookmarks")
-                        }
-                    }
+                    fetchBookmarksForSelectedBookmark()
                 }, label: {
                     Text("기업")
                         .korFont(.T4KrBd)
@@ -55,11 +47,7 @@ struct BookmarkView: View {
                 
                 Button(action: {
                     selectedBookmark = .club
-                    bookmarkViewModel.fetchBookmarks(sort: .club) { success in
-                        if !success {
-                            print("Failed to fetch club bookmarks")
-                        }
-                    }
+                    fetchBookmarksForSelectedBookmark()
                 }, label: {
                     Text("동아리")
                         .korFont(.T4KrBd)
@@ -76,7 +64,7 @@ struct BookmarkView: View {
             .cornerRadius(20)
             .padding(.all, 20)
             
-            BookmarkListView(bookmarkViewModel: bookmarkViewModel, selectedBookmark: $selectedBookmark)
+            BookmarkListView(bookmarkViewModel: bookmarkViewModel, selectedBookmark: $selectedBookmark, fetchBookmarksForSelectedBookmark: fetchBookmarksForSelectedBookmark)
             //                .navigationDestination(isPresented: $homeViewModel.goToCompanyProfileView) {
             //                    CompanyProfileView(
             //                         companyProfileViewModel: CompanyProfileViewModel(
@@ -87,10 +75,28 @@ struct BookmarkView: View {
         }
         .background(Color.bgSecondary)
         .onAppear {
-            selectedBookmark = .recent
+            fetchBookmarksForSelectedBookmark()
+        }
+    }
+    
+    private func fetchBookmarksForSelectedBookmark() {
+        switch selectedBookmark {
+        case .recent:
             bookmarkViewModel.fetchBookmarks(sort: .recent) { success in
                 if !success {
                     print("Failed to fetch recent bookmarks")
+                }
+            }
+        case .company:
+            bookmarkViewModel.fetchBookmarks(sort: .company) { success in
+                if !success {
+                    print("Failed to fetch company bookmarks")
+                }
+            }
+        case .club:
+            bookmarkViewModel.fetchBookmarks(sort: .club) { success in
+                if !success {
+                    print("Failed to fetch club bookmarks")
                 }
             }
         }
@@ -100,6 +106,7 @@ struct BookmarkView: View {
 struct BookmarkListView: View {
     var bookmarkViewModel: BookmarkListViewModel
     @Binding var selectedBookmark: BookmarkSelection
+    var fetchBookmarksForSelectedBookmark: () -> Void
     
     let columns: [GridItem] = [
         GridItem(.flexible(), spacing: 8)
@@ -109,7 +116,7 @@ struct BookmarkListView: View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 16) {
                 ForEach(bookmarkViewModel.bookmarkList) { cellViewModel in
-                    BookmarkListCell(selectedBookmark: $selectedBookmark, bookmarkViewModel: bookmarkViewModel, bookmarkListCellViewModel: cellViewModel)
+                    BookmarkListCell(selectedBookmark: $selectedBookmark, bookmarkViewModel: bookmarkViewModel, bookmarkListCellViewModel: cellViewModel, fetchBookmarksForSelectedBookmark: fetchBookmarksForSelectedBookmark)
                 }
             }
         }
@@ -122,6 +129,7 @@ struct BookmarkListCell: View {
     @Binding var selectedBookmark: BookmarkSelection
     var bookmarkViewModel: BookmarkListViewModel
     var bookmarkListCellViewModel: BookmarkListCellViewModel
+    var fetchBookmarksForSelectedBookmark: () -> Void
     
     var body: some View {
         VStack(spacing: 0) {
@@ -178,29 +186,6 @@ struct BookmarkListCell: View {
             RoundedRectangle(cornerRadius: 24)
                 .stroke(Color.line200, lineWidth: 1)
         )
-    }
-    
-    private func fetchBookmarksForSelectedBookmark() {
-        switch selectedBookmark {
-        case .recent:
-            bookmarkViewModel.fetchBookmarks(sort: .recent) { success in
-                if !success {
-                    print("Failed to fetch recent bookmarks")
-                }
-            }
-        case .company:
-            bookmarkViewModel.fetchBookmarks(sort: .company) { success in
-                if !success {
-                    print("Failed to fetch company bookmarks")
-                }
-            }
-        case .club:
-            bookmarkViewModel.fetchBookmarks(sort: .club) { success in
-                if !success {
-                    print("Failed to fetch club bookmarks")
-                }
-            }
-        }
     }
 }
 

--- a/Spon-Us/Bookmark/BookmarkViewModel.swift
+++ b/Spon-Us/Bookmark/BookmarkViewModel.swift
@@ -10,14 +10,12 @@ import Moya
 
 @Observable
 final class BookmarkListCellViewModel: Identifiable {
-    var isLoaded = false
+    let target: Int
     var companyName: String
     var imageURL: String?
-    var isBookmarked: Bool = false
-    let id: Int
     
     init(bookmarkModel: BookmarkModel) {
-        self.id = bookmarkModel.id
+        self.target = bookmarkModel.target
         self.companyName = bookmarkModel.name
         self.imageURL = bookmarkModel.imageUrl
     }
@@ -42,6 +40,24 @@ final class BookmarkListViewModel {
                 }
             case .failure(let error):
                 print("getBookmark API error: \(error.localizedDescription)")
+                completion(false)
+            }
+        }
+    }
+    
+    func postBookmark(target: Int, completion: @escaping (Bool) -> Void) {
+        provider.request(.postBookmark(target: target)) { response in
+            switch response {
+            case .success(let response):
+                do {
+                    _ = try JSONDecoder().decode(postBookmarkResponseModel.self, from: response.data)
+                    completion(true)
+                } catch {
+                    print("post bookmark decode error", error.localizedDescription)
+                    completion(false)
+                }
+            case .failure(let error):
+                print("postBookmark API error: \(error.localizedDescription)")
                 completion(false)
             }
         }

--- a/Spon-Us/Network/Models/Bookmark.swift
+++ b/Spon-Us/Network/Models/Bookmark.swift
@@ -28,3 +28,18 @@ enum BookmarkTargetType: String, Codable {
     case company = "COMPANY"
     case club = "CLUB"
 }
+
+struct postBookmarkResponseModel: Codable {
+    let statusCode: String
+    let message: String
+    let content: postBookmarkModel
+}
+
+struct postBookmarkModel: Codable {
+    let id: Int
+    let organizationId: Int
+    let target: Int
+    let targetType: String
+    let createdAt: String
+    let bookmarked: Bool
+}

--- a/Spon-Us/Network/SponusAPI.swift
+++ b/Spon-Us/Network/SponusAPI.swift
@@ -13,6 +13,7 @@ enum SponusAPI {
     case getCompany(companyId: Int)
     case getClub(clubId: Int)
     case getBookmark(sort: BookmarkTargetType)
+    case postBookmark(target: Int)
     case getSearch(keyword: String)
     case getKeyword
     case postKeyword(keyword: String)
@@ -33,7 +34,7 @@ extension SponusAPI: TargetType {
             return "/api/v2/companies/\(companyId)"
         case let .getClub(clubId):
             return "/api/v2/clubs/\(clubId)"
-        case .getBookmark:
+        case .getBookmark, .postBookmark:
             return "/api/v2/organizations/bookmarked"
         case .getSearch:
             return "/api/v2/organizations/search"
@@ -58,6 +59,8 @@ extension SponusAPI: TargetType {
             return .get
         case .getBookmark:
             return .get
+        case .postBookmark:
+            return .post
         case .getSearch:
             return .get
         case .getKeyword:
@@ -80,6 +83,8 @@ extension SponusAPI: TargetType {
         case .getClub:
             return Data()
         case .getBookmark:
+            return Data()
+        case .postBookmark:
             return Data()
         case .getSearch:
             return Data()
@@ -110,6 +115,8 @@ extension SponusAPI: TargetType {
             return .requestPlain
         case let .getBookmark(sort):
             return .requestParameters(parameters: ["sort": sort.rawValue], encoding: URLEncoding.queryString)
+        case let .postBookmark(target):
+            return .requestParameters(parameters: ["target": target], encoding: JSONEncoding.default)
         case let .getSearch(keyword):
             return .requestParameters(parameters: ["keyword": keyword], encoding: URLEncoding.queryString)
         case .getKeyword:
@@ -140,6 +147,8 @@ extension SponusAPI: TargetType {
         case .getClub:
             return auth
         case .getBookmark:
+            return auth
+        case .postBookmark:
             return auth
         case .getSearch:
             return auth


### PR DESCRIPTION
## ✅ Description
- BookmarkView API 연동하기
- 북마크 토글 9bd0f615813691ff446dd59970e5ac5114e38b46
- 남은 내용 : 화면 연결

## ⭐️ PR Point
- `현재❗️` 북마크 되어 있는걸 클릭했을 때 북마크가 해제되면 북마크가 되어 있는 조직들만 보이도록 바로 리스트가 새로고침 되면서 사라지게 했는데 
(북마크 토글 api에는 북마크한 조직에 대한 정보가 없고, 북마크 목록 조회를 하면 북마크 되어 있는 것들만(true) 나오기 때문에)
- `고민❓` 북마크 토글?이 칠해지지 않은 상태를 보여주고, 다른 페이지에 갔다가 다시 돌아오면 리스트가 새로고침 되어 있도록 하는게 좋을까요? 
그렇게 되면 북마크가 되어 있지 않은 것들도 북마크를 해제한 시점에는 보이게 되는 겁니다! 

## 📸 Simulator
https://github.com/spon-us/SponUs-iOS-Sprint2/assets/69234788/4bec15e0-ed28-4c07-a7a8-807ef10b98b2

## 💡 Issue
- Resolved: #45
